### PR TITLE
allow for numbers in firebase url

### DIFF
--- a/angularFire-seed/test/unit/configSpec.js
+++ b/angularFire-seed/test/unit/configSpec.js
@@ -10,7 +10,7 @@ describe('service', function() {
    }));
 
    it('should have FBURL beginning with https', inject(function(FBURL) {
-      expect(FBURL).toMatch(/^https:\/\/[a-zA-Z_-]+\.firebaseio\.com/i);
+      expect(FBURL).toMatch(/^https:\/\/[0-9a-zA-Z_-]+\.firebaseio\.com/i);
    }));
 
    it('should have a valid SEMVER version', inject(function(version) {


### PR DESCRIPTION
https unit test was failing with a url like https://boiling-fire-2345.firebaseio.com/ but this fixes it
