### PR TITLE
Fix formatting consistency in app.js

### DIFF
--- a/Ionic-seed/www/js/app.js
+++ b/Ionic-seed/www/js/app.js
@@ -18,7 +18,7 @@ angular.module('starter', ['ionic', 'starter.controllers', 'firebase'])
 
     // setup an abstract state for the tabs directive
     .state('tab', {
-      url: "/tab",
+      url: '/tab',
       abstract: true,
       templateUrl: "templates/tabs.html"
     })


### PR DESCRIPTION
Changed "/tab" at line 21 to '/tab' to keep quotation mark formatting consistent across app.js

![screen shot 2014-07-11 at 10 31 10 am](https://cloud.githubusercontent.com/assets/5373129/3556276/1d455eb0-0922-11e4-968f-ec841d1afe49.png)
![screen shot 2014-07-11 at 10 32 06 am](https://cloud.githubusercontent.com/assets/5373129/3556274/17696a40-0922-11e4-954b-6de428c15c2f.png)
