### PR TITLE
Fix formatting consistency in app.js

### DIFF
--- a/Ionic-seed/www/js/app.js
+++ b/Ionic-seed/www/js/app.js
@@ -18,9 +18,9 @@ angular.module('starter', ['ionic', 'starter.controllers', 'firebase'])
 
     // setup an abstract state for the tabs directive
     .state('tab', {
-      url: "/tab",
+      url: '/tab',
       abstract: true,
-      templateUrl: "templates/tabs.html"
+      templateUrl: 'templates/tabs.html'
     })
 
     // the pet tab has its own child nav-view and history


### PR DESCRIPTION
Following up on my prior pull request where I missed a similar formatting issue at line 23. 

Please disregard my prior pull request, currently #9

I noticed that quotation marks weren't consistent and I thought it would look better if the quotes were consistent throughout the file.

-Before
![screen shot 2014-07-11 at 10 31 10 am](https://cloud.githubusercontent.com/assets/5373129/3558497/73149d64-093c-11e4-8313-0be2a31c591d.png)

-After

![screen shot 2014-07-11 at 1 43 26 pm](https://cloud.githubusercontent.com/assets/5373129/3558471/60c40bae-093c-11e4-9beb-d72135a6b9b2.png)
